### PR TITLE
Fix `RCTViewManager.h file not found`

### DIFF
--- a/RCTYouTube.xcodeproj/project.pbxproj
+++ b/RCTYouTube.xcodeproj/project.pbxproj
@@ -243,6 +243,7 @@
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				USER_HEADER_SEARCH_PATHS = "$(SRCROOT)/../react-native/React/**";
 			};
 			name = Debug;
 		};
@@ -252,6 +253,7 @@
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				USER_HEADER_SEARCH_PATHS = "$(SRCROOT)/../react-native/React/**";
 			};
 			name = Release;
 		};


### PR DESCRIPTION
This spike fixes https://github.com/paramaggarwal/react-native-youtube/issues/2. Details documented in the issue.

I don't know if this is the best-practices way of handling such cases, but this change fixed the problem for me. Feel free to accept or reject at will.