### PR TITLE
Fix native event name collisions

### DIFF
--- a/RCTYouTubeManager.m
+++ b/RCTYouTubeManager.m
@@ -25,13 +25,13 @@ RCT_EXPORT_MODULE();
 {
     return @{
              RNYouTubeEventReady: @{
-                     @"registrationName": @"onReady"
+                     @"registrationName": @"onYoutubeVideoReady"
                      },
              RNYouTubeEventChangeState: @{
-                     @"registrationName": @"onChangeState"
+                     @"registrationName": @"onYoutubeVideoChangeState"
                      },
              RNYouTubeEventChangeQuality: @{
-                     @"registrationName": @"onChangeQuality"
+                     @"registrationName": @"onYoutubeVideoChangeQuality"
                      },
              RNYouTubeEventError: @{
                      @"registrationName": @"onYoutubeVideoError"

--- a/RCTYouTubeManager.m
+++ b/RCTYouTubeManager.m
@@ -34,7 +34,7 @@ RCT_EXPORT_MODULE();
                      @"registrationName": @"onChangeQuality"
                      },
              RNYouTubeEventError: @{
-                     @"registrationName": @"onError"
+                     @"registrationName": @"onYoutubeVideoError"
                      },
              };
 }

--- a/YouTube.ios.js
+++ b/YouTube.ios.js
@@ -74,13 +74,13 @@ var YouTube = React.createClass({
 
   render() {
     var style = flattenStyle([styles.base, this.props.style]);
-    
+
     var nativeProps = merge(this.props, {
       style,
       onReady: this._onReady,
       onChangeState: this._onChangeState,
       onChangeQuality: this._onChangeQuality,
-      onError: this._onError,
+      onYoutubeVideoError: this._onError,
     });
 
     return <RCTYouTube {... nativeProps} />;

--- a/YouTube.ios.js
+++ b/YouTube.ios.js
@@ -77,9 +77,9 @@ var YouTube = React.createClass({
 
     var nativeProps = merge(this.props, {
       style,
-      onReady: this._onReady,
-      onChangeState: this._onChangeState,
-      onChangeQuality: this._onChangeQuality,
+      onYoutubeVideoReady: this._onReady,
+      onYoutubeVideoChangeState: this._onChangeState,
+      onYoutubeVideoChangeQuality: this._onChangeQuality,
       onYoutubeVideoError: this._onError,
     });
 


### PR DESCRIPTION
Fixes issue https://github.com/paramaggarwal/react-native-youtube/issues/6, caused by the event name `onError` colliding with an identically named event published by React Native core `RCTImageViewManager`.

Renamed the other events as well to safeguard from incompatibilities with other libraries, or future changes in React Native.
