### PR TITLE
send video ended notification on closing video

### DIFF
--- a/RCTYouTube.m
+++ b/RCTYouTube.m
@@ -36,9 +36,23 @@
         _isPlaying = NO;
         
         self.delegate = self;
+
+        [[NSNotificationCenter defaultCenter] addObserver:self
+                                                 selector:@selector(handleWhenDoneButtonClick:)
+                                                     name:UIWindowDidBecomeHiddenNotification
+                                                   object:self.webView.window];
     }
     
     return self;
+}
+
+- (void) handleWhenDoneButtonClick:(NSNotification *) notification {
+    NSString *playerState = @"ended";
+    [_eventDispatcher sendInputEventWithName:@"youtubeVideoChangeState"
+                                        body:@{
+                                               @"state": playerState,
+                                               @"target": self.reactTag
+                                               }];
 }
 
 - (void)layoutSubviews {


### PR DESCRIPTION
When clicking on the "done" button, there is no change in state.
I am following this proposition - https://github.com/youtube/youtube-ios-player-helper/issues/149
to detect when the view disappears.
It feels a bit hackish, though, I would be happy to know if there's a nicer way to do it.

Thanks!